### PR TITLE
type instead of class

### DIFF
--- a/lib/middleman-google-analytics/helpers.rb
+++ b/lib/middleman-google-analytics/helpers.rb
@@ -19,7 +19,7 @@ module Middleman
         if options.output.to_sym == :html
           content = indent(content) unless options.minify
           if options.cookiebot
-            content_tag(:script, content, :class => 'text/plain', 'data-cookieconsent' => 'statistics')
+            content_tag(:script, content, :type => 'text/plain', 'data-cookieconsent' => 'statistics')
           else
             content_tag(:script, content)
           end  


### PR DESCRIPTION
This just fixes small typo and creates GA script tag with correct `type` attribute, instead of (unnecessary) `class` attribute,